### PR TITLE
Cross platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Fill in the 2 code sections marked "FILL ME IN".
 
 or
 
-    npm run test:watch
+    npm run testwatch
 
 ## Formatting
 

--- a/package.json
+++ b/package.json
@@ -3,13 +3,18 @@
     "description": "University of Colorado interactive DLP interview",
     "scripts": {
         "format": "prettier --write * test/pulumi-config.json **/*.ts",
-        "test": "source test/env && mocha",
-        "test:watch": "source test/env && mocha --watch"
+        "test": "run-script-os",
+        "test:nix": "source test/env && mocha",
+        "test:windows": ".\\test\\wintest.bat",
+        "testwatch": "run-script-os",
+        "testwatch:nix": "source test/env && mocha --watch",
+        "testwatch:windows": ".\\test\\wintest.bat --watch"
     },
     "devDependencies": {
         "@types/mocha": "^5.2.7",
         "@types/node": "latest",
-        "mocha": "^6.1.4"
+        "mocha": "^6.1.4",
+        "run-script-os": "^1.0.7"
     },
     "dependencies": {
         "@pulumi/pulumi": "latest",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
     "scripts": {
         "format": "prettier --write * test/pulumi-config.json **/*.ts",
         "test": "run-script-os",
-        "test:nix": "source test/env && mocha",
+        "test:nix": "bash -c 'source test/env && mocha'",
         "test:windows": ".\\test\\wintest.bat",
         "testwatch": "run-script-os",
-        "testwatch:nix": "source test/env && mocha --watch",
+        "testwatch:nix": "bash -c 'source test/env && mocha --watch'",
         "testwatch:windows": ".\\test\\wintest.bat --watch"
     },
     "devDependencies": {

--- a/test/wintest.bat
+++ b/test/wintest.bat
@@ -1,0 +1,5 @@
+set PULUMI_NODEJS_PROJECT=test-project
+set PULUMI_NODEJS_STACK=local
+set PULUMI_CONFIG={"aws:region": "us-east-1"}
+set PULUMI_TEST_MODE=true
+mocha %1


### PR DESCRIPTION
This adds support for Windows and older versions of Linux, in addition to macOS.

The `test:watch` command is changed to allow `run-script-os` to utilize the `:` delimiter.

Windows Cmd doesn't have a nice way to subshell in the contents of `pulumi-config.json`. Given this is a mostly-static test repo anyway, I felt comfortable in-lining it.

Tested with node 8.x and 12.x. Tested on:
- Windows + Powershell
- Windows + Git Bash
- Windows + Cmd
- Windows + Nodejs Shell (Cmd)
- Ubuntu 18.04
- macOS